### PR TITLE
Fix iOS 12 Crash when using code-from-Messages Smart Keyboard button

### DIFF
--- a/DigitInputView/Classes/DigitInputView.swift
+++ b/DigitInputView/Classes/DigitInputView.swift
@@ -348,7 +348,7 @@ extension DigitInputView: UITextFieldDelegate {
         
         let char = string.cString(using: .utf8)
         let isBackSpace = strcmp(char, "\\b")
-        if isBackSpace == -92 {
+        if isBackSpace == -92, let text = textField.text, !text.isEmpty {
             textField.text!.removeLast()
             didChange(true)
             return false


### PR DESCRIPTION
For whatever reason, when you tap the button in iOS 12 that populates a TextField automatically with a number found in Messages, it seems to trigger the backspace logic, even though the field is empty. This fixes the crash, though may not be the ideal solution.